### PR TITLE
Update README.md - fixing wrong informations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Here's how Picocrypt compares to other popular encryption tools.
 | Open Source    |✅ GPLv3       |✅ Multi        |✅ LGPL        |❌ No           |✅ GPLv3       |
 | Cross-Platform |✅ Yes         |✅ Yes          |❌ No          |❌ No           |✅ Yes         |
 | Size           |✅ 3 MiB       |❌ 20 MiB       |✅ 2 MiB       |✅ N/A          |❌ 50 MiB      |
-| Portable       |✅ Yes         |✅ Yes          |❌ No          |✅ Yes          |❌ No          |
-| Permissions    |✅ None        |❌ Admin        |❌ Admin       |❌ Admin        |❌ Admin       |
+| Portable       |✅ Yes         |✅ Yes          |✅ Yes         |✅ Yes          |❌ No          |
+| Permissions    |✅ None        |❌ Admin        |✅ None        |❌ Admin        |❌ Admin       |
 | Ease-Of-Use    |✅ Easy        |❌ Hard         |✅ Easy        |✅ Easy         |🟧 Medium      |
 | Cipher         |✅ XChaCha20   |✅ AES-256      |✅ AES-256     |🟧 AES-128      |✅ AES-256     |
 | Key Derivation |✅ Argon2      |🟧 PBKDF2       |❌ SHA-256     |❓ Unknown      |✅ Scrypt      |


### PR DESCRIPTION
Corrected some wrong informations for 7-Zip. 7-Zip is also available as a 100% portable version, and it also does NOT require Admin-rights. Admin is only needed if you would like to enable the “Add 7-Zip to context menu” setting. And to be honest, theoretically it is also more platform independent than the most others because you can open ZIP as well as 7Z files on Android and on iOS too, which can't be done with Picocrypt's files.